### PR TITLE
Improve download verification 

### DIFF
--- a/SICAR/sicar.py
+++ b/SICAR/sicar.py
@@ -245,9 +245,14 @@ class Sicar(Url):
         except UrlNotOkException as error:
             raise FailedToDownloadShapefileException() from error
 
-        path = Path(os.path.join(folder, f"SHAPE_{city_code}")).with_suffix(".zip")
-
         total_size = int(response.headers.get("Content-Length", 0))
+
+        content_type = response.headers.get("Content-Type", "")
+
+        if total_size == 0 or not content_type.startswith("application/zip"):
+            raise FailedToDownloadShapefileException()
+
+        path = Path(os.path.join(folder, f"SHAPE_{city_code}")).with_suffix(".zip")
 
         with open(path, "wb") as fd:
             with tqdm(
@@ -297,9 +302,14 @@ class Sicar(Url):
         except UrlNotOkException as error:
             raise FailedToDownloadCsvException() from error
 
-        path = Path(os.path.join(folder, f"CSV_{city_code}")).with_suffix(".csv")
-
         total_size = int(response.headers.get("Content-Length", 0))
+
+        content_type = response.headers.get("Content-Type", "")
+
+        if total_size == 0 or not content_type.startswith("text/csv"):
+            raise FailedToDownloadCsvException()
+
+        path = Path(os.path.join(folder, f"CSV_{city_code}")).with_suffix(".csv")
 
         with open(path, "wb") as fd:
             with tqdm(

--- a/SICAR/sicar.py
+++ b/SICAR/sicar.py
@@ -245,18 +245,18 @@ class Sicar(Url):
         except UrlNotOkException as error:
             raise FailedToDownloadShapefileException() from error
 
-        total_size = int(response.headers.get("Content-Length", 0))
+        content_length = int(response.headers.get("Content-Length", 0))
 
         content_type = response.headers.get("Content-Type", "")
 
-        if total_size == 0 or not content_type.startswith("application/zip"):
+        if content_length == 0 or not content_type.startswith("application/zip"):
             raise FailedToDownloadShapefileException()
 
         path = Path(os.path.join(folder, f"SHAPE_{city_code}")).with_suffix(".zip")
 
         with open(path, "wb") as fd:
             with tqdm(
-                total=total_size,
+                total=content_length,
                 unit="iB",
                 unit_scale=True,
                 desc=f"Downloading Shapefile for city with code '{city_code}'",
@@ -302,18 +302,18 @@ class Sicar(Url):
         except UrlNotOkException as error:
             raise FailedToDownloadCsvException() from error
 
-        total_size = int(response.headers.get("Content-Length", 0))
+        content_length = int(response.headers.get("Content-Length", 0))
 
         content_type = response.headers.get("Content-Type", "")
 
-        if total_size == 0 or not content_type.startswith("text/csv"):
+        if content_length == 0 or not content_type.startswith("text/csv"):
             raise FailedToDownloadCsvException()
 
         path = Path(os.path.join(folder, f"CSV_{city_code}")).with_suffix(".csv")
 
         with open(path, "wb") as fd:
             with tqdm(
-                total=total_size,
+                total=content_length,
                 unit="iB",
                 unit_scale=True,
                 desc=f"Downloading CSV  file for city with code '{city_code}'",

--- a/SICAR/tests/unit/sicar.py
+++ b/SICAR/tests/unit/sicar.py
@@ -255,7 +255,7 @@ class SicarTestCase(unittest.TestCase):
         folder = "csvs"
         response_mock = MagicMock()
         response_mock.ok = True
-        response_mock.headers= {
+        response_mock.headers = {
             "Content-Type": "text/csv",
             "Content-Length": 4096,
         }

--- a/SICAR/tests/unit/sicar.py
+++ b/SICAR/tests/unit/sicar.py
@@ -199,7 +199,7 @@ class SicarTestCase(unittest.TestCase):
         folder = "shapefiles"
         response_mock = MagicMock()
         response_mock.ok = True
-        response_mock.headers.return_value = {
+        response_mock.headers = {
             "Content-Type": "application/zip",
             "Content-Length": 4096,
         }
@@ -255,7 +255,7 @@ class SicarTestCase(unittest.TestCase):
         folder = "csvs"
         response_mock = MagicMock()
         response_mock.ok = True
-        response_mock.headers.return_value = {
+        response_mock.headers= {
             "Content-Type": "text/csv",
             "Content-Length": 4096,
         }

--- a/SICAR/tests/unit/sicar.py
+++ b/SICAR/tests/unit/sicar.py
@@ -231,7 +231,7 @@ class SicarTestCase(unittest.TestCase):
         with self.assertRaises(FailedToDownloadShapefileException):
             sicar._download_shapefile(city_code, captcha, folder, chunk_size)
 
-    def test_download_shapefile_html_response(self):
+    def test_download_shapefile_fails_on_html_response(self):
         city_code = "12345"
         captcha = "captcha_code"
         folder = "shapefiles"
@@ -287,7 +287,7 @@ class SicarTestCase(unittest.TestCase):
         with self.assertRaises(FailedToDownloadCsvException):
             sicar._download_csv(city_code, captcha, folder, chunk_size)
 
-    def test_download_csv_html_response(self):
+    def test_download_csv_fails_on_html_response(self):
         city_code = "12345"
         captcha = "captcha_code"
         folder = "csvs"

--- a/SICAR/tests/unit/sicar.py
+++ b/SICAR/tests/unit/sicar.py
@@ -199,9 +199,11 @@ class SicarTestCase(unittest.TestCase):
         folder = "shapefiles"
         response_mock = MagicMock()
         response_mock.ok = True
-        response_mock.headers.get.return_value = "filename.zip"
+        response_mock.headers.return_value = {
+            "Content-Type": "application/zip",
+            "Content-Length": 4096,
+        }
         response_mock.iter_content.return_value = [b"chunk1", b"chunk2"]
-        response_mock.headers.get.return_value = 4096
         mock_get.return_value = response_mock
         mock_open.return_value.__enter__.return_value = MagicMock()
         sicar = Sicar(driver=self.mocked_captcha)
@@ -229,6 +231,20 @@ class SicarTestCase(unittest.TestCase):
         with self.assertRaises(FailedToDownloadShapefileException):
             sicar._download_shapefile(city_code, captcha, folder, chunk_size)
 
+    def test_download_shapefile_html_response(self):
+        city_code = "12345"
+        captcha = "captcha_code"
+        folder = "shapefiles"
+        chunk_size = 1024
+
+        sicar = Sicar(driver=self.mocked_captcha)
+        sicar._session.get = MagicMock(
+            return_value=MagicMock(ok=True, headers={"Content-Type": "text/html"})
+        )
+
+        with self.assertRaises(FailedToDownloadShapefileException):
+            sicar._download_shapefile(city_code, captcha, folder, chunk_size)
+
     @patch.object(Sicar, "_get")
     @patch("builtins.open", new_callable=MagicMock)
     @patch.object(Path, "__init__", return_value=None)
@@ -239,9 +255,11 @@ class SicarTestCase(unittest.TestCase):
         folder = "csvs"
         response_mock = MagicMock()
         response_mock.ok = True
-        response_mock.headers.get.return_value = "filename.zip"
+        response_mock.headers.return_value = {
+            "Content-Type": "text/csv",
+            "Content-Length": 4096,
+        }
         response_mock.iter_content.return_value = [b"chunk1", b"chunk2"]
-        response_mock.headers.get.return_value = 4096
         mock_get.return_value = response_mock
         mock_open.return_value.__enter__.return_value = MagicMock()
         sicar = Sicar(driver=self.mocked_captcha)
@@ -265,6 +283,20 @@ class SicarTestCase(unittest.TestCase):
 
         sicar = Sicar(driver=self.mocked_captcha)
         sicar._session.get = MagicMock(return_value=MagicMock(ok=False))
+
+        with self.assertRaises(FailedToDownloadCsvException):
+            sicar._download_csv(city_code, captcha, folder, chunk_size)
+
+    def test_download_csv_html_response(self):
+        city_code = "12345"
+        captcha = "captcha_code"
+        folder = "csvs"
+        chunk_size = 1024
+
+        sicar = Sicar(driver=self.mocked_captcha)
+        sicar._session.get = MagicMock(
+            return_value=MagicMock(ok=True, headers={"Content-Type": "text/html"})
+        )
 
         with self.assertRaises(FailedToDownloadCsvException):
             sicar._download_csv(city_code, captcha, folder, chunk_size)


### PR DESCRIPTION
Adds a verification by checking the HTTP response headers when downloading a shapefile or CSV to ensure the content is in the expected format.